### PR TITLE
more

### DIFF
--- a/plugins/dev/aa.go
+++ b/plugins/dev/aa.go
@@ -46,5 +46,4 @@ func init() {
 	w.OnHTML(".detay-spot-category>h1", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/accesousa.go
+++ b/plugins/dev/accesousa.go
@@ -31,5 +31,4 @@ func init() {
 	w.OnHTML(".story-body>.header>.h1", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/aljazeera.go
+++ b/plugins/dev/aljazeera.go
@@ -31,5 +31,4 @@ func init() {
 	w.OnHTML("header.article-header", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/ansa.go
+++ b/plugins/dev/ansa.go
@@ -46,5 +46,4 @@ func init() {
 	w.OnHTML(".news-title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/asiatimes.go
+++ b/plugins/dev/asiatimes.go
@@ -43,5 +43,4 @@ func init() {
 	w.OnHTML("h1.entry-title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/aspendailynews.go
+++ b/plugins/dev/aspendailynews.go
@@ -31,5 +31,4 @@ func init() {
 	w.OnHTML("h1.headline", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/aspistrategist.go
+++ b/plugins/dev/aspistrategist.go
@@ -34,5 +34,4 @@ func init() {
 	w.OnHTML("div.entry-title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/bernama.go
+++ b/plugins/dev/bernama.go
@@ -28,5 +28,4 @@ func init() {
 	w.OnHTML("h1.h2", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/bnn.go
+++ b/plugins/dev/bnn.go
@@ -31,5 +31,4 @@ func init() {
 	w.OnHTML(".tdb-title-text", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/bnnbloomberg.go
+++ b/plugins/dev/bnnbloomberg.go
@@ -46,5 +46,4 @@ func init() {
 	w.OnHTML(".media-content>.headline", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title = element.Text
 	})
-
 }

--- a/plugins/dev/brisbanetimes.go
+++ b/plugins/dev/brisbanetimes.go
@@ -37,5 +37,4 @@ func init() {
 	w.OnHTML("h1[data-testid=\"headline\"]", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/businessmirror.go
+++ b/plugins/dev/businessmirror.go
@@ -29,7 +29,7 @@ func init() {
 		w.Visit(element.Attr("href"), crawlers.Index)
 	})
 	w.OnHTML("div.cs-page__author-social > div > div", func(element *colly.HTMLElement, ctx *crawlers.Context) {
-		ctx.Link = append(ctx.Authors, element.Text)
+		ctx.Email = element.Text
 	})
 	w.OnHTML("h1.cs-page__title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Name += element.Text
@@ -43,5 +43,4 @@ func init() {
 	w.OnHTML(".cs-entry__title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/bussinessinsider.go
+++ b/plugins/dev/bussinessinsider.go
@@ -34,5 +34,4 @@ func init() {
 	w.OnHTML("div.wrapper.clearfix.article-content-wrapper > div.box-lhs-width.float-left > div > div.article_content.clearfix > div > article > div.mobile_padding > h1", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/bworldonline.go
+++ b/plugins/dev/bworldonline.go
@@ -31,5 +31,4 @@ func init() {
 	w.OnHTML("h1.entry-title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/channelnewsasia.go
+++ b/plugins/dev/channelnewsasia.go
@@ -31,5 +31,4 @@ func init() {
 	w.OnHTML("h1.h1--page-title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/chinamil.go
+++ b/plugins/dev/chinamil.go
@@ -40,5 +40,4 @@ func init() {
 	w.OnHTML("div.title>h1", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/cnn.go
+++ b/plugins/dev/cnn.go
@@ -52,5 +52,4 @@ func init() {
 	w.OnHTML(".PageHead__title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/ctk.go
+++ b/plugins/dev/ctk.go
@@ -25,5 +25,4 @@ func init() {
 	w.OnHTML("div.box-article>h1", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/dailymail.go
+++ b/plugins/dev/dailymail.go
@@ -34,5 +34,4 @@ func init() {
 	w.OnHTML("div.article-text>h2", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/dailypioneer.go
+++ b/plugins/dev/dailypioneer.go
@@ -40,5 +40,4 @@ func init() {
 	w.OnHTML("h2[itemprop=\"headline\"]", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/dailysabah.go
+++ b/plugins/dev/dailysabah.go
@@ -37,5 +37,4 @@ func init() {
 	w.OnHTML("h1.main_page_title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/dailytimes.go
+++ b/plugins/dev/dailytimes.go
@@ -37,5 +37,4 @@ func init() {
 	w.OnHTML("h1.entry-title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/deccanherald.go
+++ b/plugins/dev/deccanherald.go
@@ -31,5 +31,4 @@ func init() {
 	w.OnHTML("h1#page-title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/digitaljournal.go
+++ b/plugins/dev/digitaljournal.go
@@ -43,5 +43,4 @@ func init() {
 	w.OnHTML("h1.zox-post-title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/dnaindia.go
+++ b/plugins/dev/dnaindia.go
@@ -37,5 +37,4 @@ func init() {
 	w.OnHTML("div.article-box-details>h1", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/efe.go
+++ b/plugins/dev/efe.go
@@ -34,5 +34,4 @@ func init() {
 	w.OnHTML("h1.entry-title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/ejinsight.go
+++ b/plugins/dev/ejinsight.go
@@ -61,5 +61,4 @@ func init() {
 	w.OnHTML("div.content_text>h1", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/ekantipur.go
+++ b/plugins/dev/ekantipur.go
@@ -31,5 +31,4 @@ func init() {
 	w.OnHTML("div.row>div>div.article-header>h1", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/euronews.go
+++ b/plugins/dev/euronews.go
@@ -31,5 +31,4 @@ func init() {
 	w.OnHTML("div.swiper-slide-active>div.o-article>div.o-article__body>div>article>header>div>h1.c-article-title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/factcheck.go
+++ b/plugins/dev/factcheck.go
@@ -31,5 +31,4 @@ func init() {
 	w.OnHTML("h1.content-title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/fastmarkets.go
+++ b/plugins/dev/fastmarkets.go
@@ -37,5 +37,4 @@ func init() {
 	w.OnHTML("h1.Page-headline", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/federalnewsnetwork.go
+++ b/plugins/dev/federalnewsnetwork.go
@@ -29,7 +29,7 @@ func init() {
 		w.Visit(element.Attr("href"), crawlers.Index)
 	})
 	w.OnHTML("ul.author__meta>li", func(element *colly.HTMLElement, ctx *crawlers.Context) {
-		ctx.Link = append(ctx.Authors, element.Text)
+		ctx.Email = element.Text
 	})
 	w.OnHTML("h1.author__name", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Name += element.Text
@@ -49,5 +49,4 @@ func init() {
 	w.OnHTML(".author__title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/financialbuzz.go
+++ b/plugins/dev/financialbuzz.go
@@ -28,5 +28,4 @@ func init() {
 	w.OnHTML("h1.entry-title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/freepressjournal.go
+++ b/plugins/dev/freepressjournal.go
@@ -55,5 +55,4 @@ func init() {
 	w.OnHTML("h1.article-heading", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/globalenergymonitor.go
+++ b/plugins/dev/globalenergymonitor.go
@@ -20,7 +20,7 @@ func init() {
 		}
 	})
 	w.OnHTML("ul.meta", func(element *colly.HTMLElement, ctx *crawlers.Context) {
-		ctx.File = append(ctx.Authors, element.Text)
+		ctx.File = append(ctx.File, element.Text)
 	})
 
 	w.OnHTML("ul.meta", func(element *colly.HTMLElement, ctx *crawlers.Context) {
@@ -44,5 +44,4 @@ func init() {
 	w.OnHTML("h1.page-header__title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/globalnews.go
+++ b/plugins/dev/globalnews.go
@@ -49,5 +49,4 @@ func init() {
 	w.OnHTML("div.author-title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/gov.go
+++ b/plugins/dev/gov.go
@@ -31,5 +31,4 @@ func init() {
 	w.OnHTML("div.banner-content__title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/governmentnews.go
+++ b/plugins/dev/governmentnews.go
@@ -34,5 +34,4 @@ func init() {
 	w.OnHTML("h1.entry-title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/haberler.go
+++ b/plugins/dev/haberler.go
@@ -37,5 +37,4 @@ func init() {
 	w.OnHTML(".hbptHead>h1", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/hbr.go
+++ b/plugins/dev/hbr.go
@@ -43,5 +43,4 @@ func init() {
 	w.OnHTML("h1.article-hed", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/hellenicshippingnews.go
+++ b/plugins/dev/hellenicshippingnews.go
@@ -31,5 +31,4 @@ func init() {
 	w.OnHTML("h1.post-title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/huffpost.go
+++ b/plugins/dev/huffpost.go
@@ -35,7 +35,7 @@ func init() {
 		w.Visit(element.Attr("href"), crawlers.Index)
 	})
 	w.OnHTML("div.author--bio__details>div", func(element *colly.HTMLElement, ctx *crawlers.Context) {
-		ctx.Link = append(ctx.Authors, element.Text)
+		ctx.Email = element.Text
 	})
 	w.OnHTML("h1.author--bio__name", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Name += element.Text
@@ -52,5 +52,4 @@ func init() {
 	w.OnHTML("p.author--bio__title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/india.go
+++ b/plugins/dev/india.go
@@ -31,5 +31,4 @@ func init() {
 	w.OnHTML("body > section.main-container.articledetails-page > div.container > div > div > div:nth-child(3)", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/investing.go
+++ b/plugins/dev/investing.go
@@ -28,5 +28,4 @@ func init() {
 	w.OnHTML(".articleHeader", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/jiji.go
+++ b/plugins/dev/jiji.go
@@ -49,5 +49,4 @@ func init() {
 	w.OnHTML("h1.text4L", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/lawfareblog.go
+++ b/plugins/dev/lawfareblog.go
@@ -32,7 +32,7 @@ func init() {
 		w.Visit(element.Attr("href"), crawlers.Index)
 	})
 	w.OnHTML("li.author-info__twitter", func(element *colly.HTMLElement, ctx *crawlers.Context) {
-		ctx.Link = append(ctx.Authors, element.Text)
+		ctx.Email = element.Text
 	})
 	w.OnHTML("h1.title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Name += element.Text
@@ -49,5 +49,4 @@ func init() {
 	w.OnHTML("h1.title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/livemint.go
+++ b/plugins/dev/livemint.go
@@ -52,5 +52,4 @@ func init() {
 	w.OnHTML(" div.authorDesc > h5", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/magicvalley.go
+++ b/plugins/dev/magicvalley.go
@@ -25,5 +25,4 @@ func init() {
 	w.OnHTML(".headline", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/marketersmedia.go
+++ b/plugins/dev/marketersmedia.go
@@ -34,5 +34,4 @@ func init() {
 	w.OnHTML("section.single>h1", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/markets.go
+++ b/plugins/dev/markets.go
@@ -64,5 +64,4 @@ func init() {
 	w.OnHTML(".article-title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/mb.go
+++ b/plugins/dev/mb.go
@@ -31,5 +31,4 @@ func init() {
 	w.OnHTML(".title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/mbn.go
+++ b/plugins/dev/mbn.go
@@ -58,5 +58,4 @@ func init() {
 	w.OnHTML(".title_box", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/mcdowellnews.go
+++ b/plugins/dev/mcdowellnews.go
@@ -31,5 +31,4 @@ func init() {
 	w.OnHTML(".headline", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/midweekherald.go
+++ b/plugins/dev/midweekherald.go
@@ -34,5 +34,4 @@ func init() {
 	w.OnHTML("h1.mar-article__headline", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/mirror.go
+++ b/plugins/dev/mirror.go
@@ -1,4 +1,4 @@
-package production
+package dev
 
 import (
 	"megaCrawler/crawlers"
@@ -46,5 +46,4 @@ func init() {
 	w.OnHTML(".author-profile__title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/moneycontrol.go
+++ b/plugins/dev/moneycontrol.go
@@ -43,5 +43,4 @@ func init() {
 	w.OnHTML(".article_title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/news.go
+++ b/plugins/dev/news.go
@@ -49,5 +49,4 @@ func init() {
 	w.OnHTML("div.conBox>div>h1", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/newsGovHk.go
+++ b/plugins/dev/newsGovHk.go
@@ -40,5 +40,4 @@ func init() {
 	w.OnHTML("h1.news-title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/newsweek.go
+++ b/plugins/dev/newsweek.go
@@ -40,5 +40,4 @@ func init() {
 	w.OnHTML("h1.title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/nikkei.go
+++ b/plugins/dev/nikkei.go
@@ -49,5 +49,4 @@ func init() {
 	w.OnHTML("h1.article-header__title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/nst.go
+++ b/plugins/dev/nst.go
@@ -43,5 +43,4 @@ func init() {
 	w.OnHTML("h1.page-title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/oreanda-news.go
+++ b/plugins/dev/oreanda-news.go
@@ -34,5 +34,4 @@ func init() {
 	w.OnHTML("h1.h-article", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/philstar.go
+++ b/plugins/dev/philstar.go
@@ -25,5 +25,4 @@ func init() {
 	w.OnHTML("div.article__title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/philstockworld.go
+++ b/plugins/dev/philstockworld.go
@@ -40,5 +40,4 @@ func init() {
 	w.OnHTML("h1.tdb-title-text", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/pna.go
+++ b/plugins/dev/pna.go
@@ -31,5 +31,4 @@ func init() {
 	w.OnHTML("div.page-header", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/presstv.go
+++ b/plugins/dev/presstv.go
@@ -46,5 +46,4 @@ func init() {
 	w.OnHTML("h1.news-title-container", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/prokerala.go
+++ b/plugins/dev/prokerala.go
@@ -37,5 +37,4 @@ func init() {
 	w.OnHTML("header.page-header", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/releasewire.go
+++ b/plugins/dev/releasewire.go
@@ -28,5 +28,4 @@ func init() {
 	w.OnHTML("#newswire > div > h1", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/rferl.go
+++ b/plugins/dev/rferl.go
@@ -34,5 +34,4 @@ func init() {
 	w.OnHTML("h1.title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/rttnews.go
+++ b/plugins/dev/rttnews.go
@@ -43,5 +43,4 @@ func init() {
 	w.OnHTML("div.storyHeadline", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/seenews.go
+++ b/plugins/dev/seenews.go
@@ -52,5 +52,4 @@ func init() {
 	w.OnHTML("div.heading--content>h1", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/sse.go
+++ b/plugins/dev/sse.go
@@ -34,5 +34,4 @@ func init() {
 	w.OnHTML("div.article>h1", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/stltodey.go
+++ b/plugins/dev/stltodey.go
@@ -25,5 +25,4 @@ func init() {
 	w.OnHTML(".headline", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/taiwannews.go
+++ b/plugins/dev/taiwannews.go
@@ -40,5 +40,4 @@ func init() {
 	w.OnHTML("h1.article-title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/thebreezepaper.go
+++ b/plugins/dev/thebreezepaper.go
@@ -34,5 +34,4 @@ func init() {
 	w.OnHTML("h1.BlogItem-title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/thebruneian.go
+++ b/plugins/dev/thebruneian.go
@@ -37,5 +37,4 @@ func init() {
 	w.OnHTML("h1.evo-entry-title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/thehimalayantimes.go
+++ b/plugins/dev/thehimalayantimes.go
@@ -34,5 +34,4 @@ func init() {
 	w.OnHTML("h1.alith_post_title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/thenewslens.go
+++ b/plugins/dev/thenewslens.go
@@ -47,7 +47,7 @@ func init() {
 		w.Visit(element.Attr("href"), crawlers.Index)
 	})
 	w.OnHTML("div.author-header>div.share-box", func(element *colly.HTMLElement, ctx *crawlers.Context) {
-		ctx.Link = append(ctx.Authors, element.Text)
+		ctx.Email = element.Text
 	})
 	w.OnHTML("div.author-header>div.name", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Name += element.Text
@@ -73,5 +73,4 @@ func init() {
 	w.OnHTML("h1.article-title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/thenorthlines.go
+++ b/plugins/dev/thenorthlines.go
@@ -40,5 +40,4 @@ func init() {
 	w.OnHTML("h1.entry-title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/thesouthern.go
+++ b/plugins/dev/thesouthern.go
@@ -28,5 +28,4 @@ func init() {
 	w.OnHTML(".headline", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/thestar.go
+++ b/plugins/dev/thestar.go
@@ -58,5 +58,4 @@ func init() {
 	w.OnHTML(".articleDetails>.headline", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/theweek.go
+++ b/plugins/dev/theweek.go
@@ -58,5 +58,4 @@ func init() {
 	w.OnHTML(".article-title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/todayonline.go
+++ b/plugins/dev/todayonline.go
@@ -43,5 +43,4 @@ func init() {
 	w.OnHTML(".h1--author-name", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Name += element.Text
 	})
-
 }

--- a/plugins/dev/tribune.go
+++ b/plugins/dev/tribune.go
@@ -61,5 +61,4 @@ func init() {
 	w.OnHTML("div.story-box-section>h1", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/uniindia.go
+++ b/plugins/dev/uniindia.go
@@ -40,5 +40,4 @@ func init() {
 	w.OnHTML("h1.storyheadline", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/uwire.go
+++ b/plugins/dev/uwire.go
@@ -28,5 +28,4 @@ func init() {
 	w.OnHTML("div.post-alt>h1", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/valuewalk.go
+++ b/plugins/dev/valuewalk.go
@@ -32,5 +32,4 @@ func init() {
 	w.OnHTML("h1.entry-title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/vietnamnews.go
+++ b/plugins/dev/vietnamnews.go
@@ -28,5 +28,4 @@ func init() {
 	w.OnHTML("h1.headline", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/vietnamnewsgazette.go
+++ b/plugins/dev/vietnamnewsgazette.go
@@ -37,5 +37,4 @@ func init() {
 	w.OnHTML("h1.entry-title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/webindia123.go
+++ b/plugins/dev/webindia123.go
@@ -37,5 +37,4 @@ func init() {
 	w.OnHTML(".s-left>h1", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/webnewswire.go
+++ b/plugins/dev/webnewswire.go
@@ -25,5 +25,4 @@ func init() {
 	w.OnHTML("h1.entry-title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/wtop.go
+++ b/plugins/dev/wtop.go
@@ -46,5 +46,4 @@ func init() {
 	w.OnHTML("h1.page__single--title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/dev/yenisafak.go
+++ b/plugins/dev/yenisafak.go
@@ -23,10 +23,10 @@ func init() {
 		w.Visit(element.Attr("href"), crawlers.Index)
 	})
 	w.OnHTML(".author-about-card-social-media>a", func(element *colly.HTMLElement, ctx *crawlers.Context) {
-		ctx.Link = append(ctx.Authors, element.Text)
+		ctx.Email = element.Text
 	})
 	w.OnHTML("#__layout > div > div.layout-content > div.detail-page.author-column-detail-page > div > div.author-about-card > div.author-about-card-container > div > div > div.author-about-card-content__author-info-content > div.author-about-card-social-media > div > a", func(element *colly.HTMLElement, ctx *crawlers.Context) {
-		ctx.Link = append(ctx.Authors, element.Text)
+		ctx.Email = element.Text
 	})
 	w.OnHTML(".ys-link>a", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		w.Visit(element.Attr("href"), crawlers.News)
@@ -37,5 +37,4 @@ func init() {
 	w.OnHTML(".author-about-card-meta__title", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/production/bbc2.go
+++ b/plugins/production/bbc2.go
@@ -49,5 +49,4 @@ func init() {
 	w.OnHTML(".article-headline__text", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/production/bihr.go
+++ b/plugins/production/bihr.go
@@ -3,6 +3,8 @@ package production
 import (
 	"megaCrawler/crawlers"
 	"strings"
+
+	"github.com/gocolly/colly/v2"
 )
 
 func init() {

--- a/plugins/production/bruegel.go
+++ b/plugins/production/bruegel.go
@@ -1,9 +1,10 @@
 package production
 
 import (
-	"github.com/gocolly/colly/v2"
 	"megaCrawler/crawlers"
 	"strings"
+
+	"github.com/gocolly/colly/v2"
 )
 
 func init() {

--- a/plugins/production/cejil.go
+++ b/plugins/production/cejil.go
@@ -1,9 +1,10 @@
 package production
 
 import (
-	"github.com/gocolly/colly/v2"
 	"megaCrawler/crawlers"
 	"strings"
+
+	"github.com/gocolly/colly/v2"
 )
 
 func init() {
@@ -32,7 +33,6 @@ func init() {
 	// 获取 Title
 	w.OnHTML(`article > div.box-content > h1`, func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title = strings.TrimSpace(element.Text)
-		ctx.
 	})
 
 	// 获取 PublicationTime

--- a/plugins/production/centerforsecuritypolicy.go
+++ b/plugins/production/centerforsecuritypolicy.go
@@ -3,6 +3,8 @@ package production
 import (
 	"megaCrawler/crawlers"
 	"strings"
+
+	"github.com/gocolly/colly/v2"
 )
 
 func init() {

--- a/plugins/production/harvard.go
+++ b/plugins/production/harvard.go
@@ -1,8 +1,9 @@
 package production
 
 import (
-	"github.com/gocolly/colly/v2"
 	"megaCrawler/crawlers"
+
+	"github.com/gocolly/colly/v2"
 )
 
 func init() {

--- a/plugins/production/moniter.go
+++ b/plugins/production/moniter.go
@@ -34,5 +34,4 @@ func init() {
 	w.OnHTML("h1.title-medium", func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.Title += element.Text
 	})
-
 }

--- a/plugins/production/seruminstitute.go
+++ b/plugins/production/seruminstitute.go
@@ -27,7 +27,6 @@ func init() {
 	// 获取 SubTitle
 	w.OnHTML(`.career-content > h2`, func(element *colly.HTMLElement, ctx *crawlers.Context) {
 		ctx.SubTitle = strings.TrimSpace(element.Text)
-
 	})
 
 	// 获取 PublicationTime & Authors 或是 PublicationTime


### PR DESCRIPTION
128个都在这，没debug
https://www.stltoday.com 
爬了一些之后就无法往后爬，要注册，其中也有反爬手段

https://www.miamiherald.com
要注册

https://www.news18.com
selecot有点奇怪

https://thehill.com
selector有点奇怪

https://sg.finance.yahoo.com
selector有点奇怪

https://www.theguardian.com
selector有点奇怪


https://www.standard.co.uk
selector有点奇怪

https://www.usnews.com
selector有点奇怪

https://www.upi.com
selector有点奇怪

https://www.nytimes.com
要注册

https://www.chemicalweekly.com
要注册

http://en.qstheory.cn
selector有点奇怪

https://www.theglobeandmail.com
selector有点奇怪

https://www.abc.net.au
selector有点奇怪

https://timesofindia.indiatimes.com
selector有点奇怪

http://futures.etnetchina.com.cn
打不开

https://ians.in
要注册

https://epaper.assamtribune.com
要注册

