### PR TITLE
Draft by 倪潍杰

### DIFF
--- a/plugins/dev/1009
+++ b/plugins/dev/1009
@@ -23,7 +23,7 @@ func init() {
 		TextLanguage: "",
 	}
 
-// Just a draft,please ignore it. 
+	// Just a draft,please ignore it.
 
 	extractorConfig.Apply(engine)
 
@@ -34,7 +34,10 @@ func init() {
 	engine.OnHTML("title", func(element *colly.HTMLElement, ctx *crawlers.Context) { //填写a的class
 		engine.Visit(element.Attr("href"), crawlers.News)
 	})
-	engine.OnHTML("entry-content", func(element *colly.HTMLElement, ctx *crawlers.Context) { //填写a的class
+	engine.OnHTML("#content > header > div > div > div > div > h1", func(element *colly.HTMLElement, ctx *crawlers.Context) { //填写a的class
+		ctx.Title = element.Text
+	})
+	engine.OnHTML("#post-32470 > div.entry-content > p", func(element *colly.HTMLElement, ctx *crawlers.Context) { //填写a的class
 		ctx.Content = element.Text
 	})
 }

--- a/plugins/dev/1009
+++ b/plugins/dev/1009
@@ -1,0 +1,40 @@
+package dev
+
+import (
+	"megaCrawler/crawlers"
+	"megaCrawler/extractors"
+
+	"github.com/gocolly/colly/v2"
+)
+
+func init() {
+	engine := crawlers.Register("1009", "Asia Maritime Transparency Initiative", "https://amti.csis.org/")
+
+	engine.SetStartingURLs([]string{"https://amti.csis.org/"})
+
+	extractorConfig := extractors.Config{
+		Author:       true,
+		Image:        true,
+		Language:     true,
+		PublishDate:  true,
+		Tags:         true,
+		Text:         false,
+		Title:        true,
+		TextLanguage: "",
+	}
+
+// Just a draft,please ignore it. 
+
+	extractorConfig.Apply(engine)
+
+	engine.OnResponse(func(response *colly.Response, ctx *crawlers.Context) {
+		println(string(response.Body))
+	})
+
+	engine.OnHTML("title", func(element *colly.HTMLElement, ctx *crawlers.Context) { //填写a的class
+		engine.Visit(element.Attr("href"), crawlers.News)
+	})
+	engine.OnHTML("entry-content", func(element *colly.HTMLElement, ctx *crawlers.Context) { //填写a的class
+		ctx.Content = element.Text
+	})
+}


### PR DESCRIPTION
## 概要

草稿在 dev /1009，仅包含了链接、标题和文本的初步草稿。

## 关于网络问题
如果知道了代理服务器的地址和端口，如何在终端中设置HTTP_PROXY呢？
小黑猫（Clash for Windows）的IP地址与端口示例如下：

    name: '上海联通转日本NTT3[Trojan][倍率:0.8]'
    type: trojan
    server: shcuac.aag436.ccddn4.icu
    port: 65524
    password: <REDACTED>
    sni: dl.shcujpntt3.cc.tjcct.xyz
    udp: true
